### PR TITLE
BSP-405: Making sure feature-toggled file appears in spreadsheet afte…

### DIFF
--- a/src/main/lib/file-utils.js
+++ b/src/main/lib/file-utils.js
@@ -37,22 +37,21 @@ const getJsonFilePaths = (directory, exclusions = []) => {
     path => !exclusions.some(exclusion => path.split('/').some(chunk => matcher.isMatch(chunk, exclusion))));
 };
 
-function toRelativePaths(array, root) {
+function toRelativePaths (array, root) {
   return array.map(file => path.relative(root, file))
-    .sort(function (a, b) {
-      const filename_a = a.replace('\.json', '');
-      const filename_b = b.replace('\.json', '');
+    .sort((a, b) => {
+      const firstFilename = a.replace('.json', '');
+      const secondFilename = b.replace('.json', '');
 
       //Looking for files with similar names
-      if (filename_b.startsWith(filename_a)) {
+      if (secondFilename.startsWith(firstFilename)) {
         //Found files that have nearly identical names. Put longer name later.
         return -1;
       } else {
         //Otherwise, just return in their original order
         return 0;
       }
-    })
-    ;
+    });
 }
 
 module.exports = {

--- a/src/main/lib/file-utils.js
+++ b/src/main/lib/file-utils.js
@@ -37,8 +37,22 @@ const getJsonFilePaths = (directory, exclusions = []) => {
     path => !exclusions.some(exclusion => path.split('/').some(chunk => matcher.isMatch(chunk, exclusion))));
 };
 
-function toRelativePaths (array, root) {
-  return array.map(file => path.relative(root, file));
+function toRelativePaths(array, root) {
+  return array.map(file => path.relative(root, file))
+    .sort(function (a, b) {
+      const filename_a = a.replace('\.json', '');
+      const filename_b = b.replace('\.json', '');
+
+      //Looking for files with similar names
+      if (filename_b.startsWith(filename_a)) {
+        //Found files that have nearly identical names. Put longer name later.
+        return -1;
+      } else {
+        //Otherwise, just return in their original order
+        return 0;
+      }
+    })
+    ;
 }
 
 module.exports = {

--- a/src/test/file-utils.test.js
+++ b/src/test/file-utils.test.js
@@ -7,17 +7,19 @@ describe('file-utils', () => {
     it('lists all files in the directory if no filters are provided', () => {
       const filesInDirectory = fileUtils.getJsonFilePaths('./src/test/fixtures/listFiles');
 
-      assert.equal(filesInDirectory.length, 2);
+      assert.equal(filesInDirectory.length, 3);
       assert.equal(filesInDirectory[0], 'NotExcluded.json');
       assert.equal(filesInDirectory[1], 'UserProfile.json');
+      assert.equal(filesInDirectory[2], 'UserProfile-nonprod.json');
     });
 
     it('lists all files in the directory if filters are not matching any of the file', () => {
       const filesInDirectory = fileUtils.getJsonFilePaths('./src/test/fixtures/listFiles', ['UserProfile']);
 
-      assert.equal(filesInDirectory.length, 2);
+      assert.equal(filesInDirectory.length, 3);
       assert.equal(filesInDirectory[0], 'NotExcluded.json');
       assert.equal(filesInDirectory[1], 'UserProfile.json');
+      assert.equal(filesInDirectory[2], 'UserProfile-nonprod.json');
     });
 
     it('excludes the directory which is on the dir list', () => {
@@ -28,7 +30,7 @@ describe('file-utils', () => {
     });
 
     it('excludes the files from the exclude list', () => {
-      const filesInDirectory = fileUtils.getJsonFilePaths('./src/test/fixtures/listFiles', ['UserProfile.json']);
+      const filesInDirectory = fileUtils.getJsonFilePaths('./src/test/fixtures/listFiles', ['UserProfile.json', 'UserProfile-nonprod.json']);
 
       assert.equal(filesInDirectory.length, 1);
       assert.equal(filesInDirectory[0], 'NotExcluded.json');

--- a/src/test/fixtures/listFiles/UserProfile-nonprod.json
+++ b/src/test/fixtures/listFiles/UserProfile-nonprod.json
@@ -1,0 +1,9 @@
+[
+  {
+    "LiveFrom": "01/01/2017",
+    "UserIDAMId": "local-authority-nonprod@example.com",
+    "WorkBasketDefaultJurisdiction": "PUBLICLAW",
+    "WorkBasketDefaultCaseType": "DRAFT",
+    "WorkBasketDefaultState": "1_Initiation"
+  }
+]


### PR DESCRIPTION
…r non-feature-toggled file.

### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/BSP-405


### Change description ###
Feature-toggled items are being added first and because of the sequential nature in which CCD loads the spreadsheet, if this feature-toggled component has a dependency on a component which is not feature-toggled, then uploading this spreadsheet will fail.